### PR TITLE
Add_clobber_support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	"forwardPorts": [10002],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "/usr/share/powershell/pwsh -f ./bootstrap.ps1",
+	"postCreateCommand": "/usr/share/powershell/pwsh -f ./bootstrap.ps1 -force",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -105,6 +105,8 @@ else {
 Write-Host 'Writing about_.. help article data to local Azurite table..'
 ./explainpowershell.helpcollector/helpwriter.ps1 -HelpDataCacheFilename $fileName
 
+Import-Module "$PSScriptRoot/explainpowershell.analysisservice.tests/testfiles/myTestModule.psm1"
+
 $modulesToProcess = Get-Content "$PSScriptRoot/explainpowershell.metadata/defaultModules.json"
 | ConvertFrom-Json
 
@@ -123,6 +125,11 @@ foreach ($module in $modulesToProcess) {
 
     Write-Host "Writing help for module '$($module.Name)' to local Azurite table.."
     ./explainpowershell.helpcollector/helpwriter.ps1 -HelpDataCacheFilename $fileName
+
+    if ($module.name -eq 'myTestModule') {
+        Remove-Module myTestModule
+        Import-Module "$PSScriptRoot/explainpowershell.analysisservice.tests/testfiles/myConflictingTestModule.psm1"
+    }
 }
 
 Write-Host -ForegroundColor Green 'Running tests to see if everything works'

--- a/explainpowershell.analysisservice.tests/Get-HelpDatabaseData.Tests.ps1
+++ b/explainpowershell.analysisservice.tests/Get-HelpDatabaseData.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'Get-HelpDatabaseData' {
 
     $commandsToCheck = Get-Content "$PSScriptRoot/../explainpowershell.metadata/defaultModules.json"
     | ConvertFrom-Json
+    | Where-Object {$_.name -notmatch '^myTestModule$|^myConflictingTestModule$'}
     | ForEach-Object {
         $cmd = Get-Command -Module $_.name | Select-Object -First 1
         [psobject]@{

--- a/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
+++ b/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
@@ -12,7 +12,7 @@ Describe "make_module_aware" {
         [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code
         $content = $result.Content | ConvertFrom-Json
         $content.Explanations[0].HelpResult.ModuleName | Should -BeExactly 'myTestModule'
-        $content.Explanations[0].CommandName | Should -BeExactly 'get-testinfo'
+        $content.Explanations[0].CommandName | Should -BeExactly 'Get-TestInfo'
         $content.Explanations[0].HelpResult.ModuleProjectUri | Should -BeExactly 'https://www.explainpowershell.com'
     }
 }

--- a/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
+++ b/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
@@ -1,5 +1,22 @@
 using namespace Microsoft.PowerShell.Commands
 
+Describe "make_module_aware" {
+    BeforeAll {
+        . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+        . $PSScriptRoot/Start-FunctionApp.ps1
+        . $PSScriptRoot/Test-IsAzuriteUp.ps1
+    }
+
+    It "Switches to the right module on demand" {
+        $code = 'myTestModule\get-testinfo'
+        [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code
+        $content = $result.Content | ConvertFrom-Json
+        $content.Explanations[0].HelpResult.ModuleName | Should -BeExactly 'myTestModule'
+        $content.Explanations[0].CommandName | Should -BeExactly 'get-testinfo'
+        $content.Explanations[0].HelpResult.ModuleProjectUri | Should -BeExactly 'https://www.explainpowershell.com'
+    }
+}
+
 Describe "Invoke-SyntaxAnalyzer" {
     BeforeAll {
         . $PSCommandPath.Replace('.Tests.ps1', '.ps1')

--- a/explainpowershell.analysisservice.tests/testfiles/myConflictingTestModule.psm1
+++ b/explainpowershell.analysisservice.tests/testfiles/myConflictingTestModule.psm1
@@ -1,0 +1,18 @@
+<#
+.SYNOPSIS
+    A function that is ALSO a testfunction, just like myTestModule\Get-TestInfo.
+.DESCRIPTION
+    A funnction to test our clobber support with
+.LINK
+    https://www.explainpowershell.com
+.EXAMPLE
+    Get-TestInfo -IsAlsoADummy
+    Get-TestInfo will return if the switch parameter 'IsAlsoADummy' is present or not. This will return $true
+#>
+function Get-TestInfo {
+    [CmdletBinding()]
+    param (
+        [Switch]$IsAlsoADummy
+    )
+    return $IsAlsoADummy
+}

--- a/explainpowershell.analysisservice.tests/testfiles/myTestModule.psm1
+++ b/explainpowershell.analysisservice.tests/testfiles/myTestModule.psm1
@@ -1,0 +1,18 @@
+<#
+.SYNOPSIS
+    A dummy function to test stuff with.
+.DESCRIPTION
+    A longer description of the dummy test function, its purpose, common use cases, etc.
+.LINK
+    https://www.explainpowershell.com
+.EXAMPLE
+    Get-TestInfo -IsDummy
+    Get-TestInfo will return if the switch parameter 'IsDummy' is present or not. This will return $true
+#>
+function Get-TestInfo {
+    [CmdletBinding()]
+    param (
+        [Switch]$IsDummy
+    )
+    return $IsDummy
+}

--- a/explainpowershell.analysisservice/AstVisitorExplainer.cs
+++ b/explainpowershell.analysisservice/AstVisitorExplainer.cs
@@ -76,10 +76,8 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         private HelpEntity HelpTableQuery(string resolvedCmd, string moduleName)
         {
-            string filter = TableServiceClient.CreateQueryFilter($"PartitionKey eq {PartitionKey} and RowKey eq {resolvedCmd.ToLower()}{filterChar}{moduleName}");
-            var entities = tableClient.Query<HelpEntity>(filter: filter);
-            var helpResult = entities.FirstOrDefault();
-            return helpResult;
+            var rowKey = $"{resolvedCmd.ToLower()}{filterChar}{moduleName.ToLower()}";
+            return HelpTableQuery(rowKey);
         }
 
         private List<HelpEntity> HelpTableQueryRange(string resolvedCmd)
@@ -269,14 +267,17 @@ namespace ExplainPowershell.SyntaxAnalyzer
             {
                 var helpResults = HelpTableQueryRange(resolvedCmd);
                 helpResult = helpResults?.FirstOrDefault();
+                // TODO: Warn user that more than one explanation is available
             }
             else
             {
                 helpResult = HelpTableQuery(resolvedCmd, moduleName);
                 if (string.IsNullOrEmpty(helpResult?.ModuleName))
                 {
-                    helpResult = new();
-                    helpResult.ModuleName = moduleName;
+                    helpResult = new()
+                    {
+                        ModuleName = moduleName
+                    };
                 }
             }
 
@@ -602,7 +603,7 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            // TODO
+            // TODO: add function definition explanation
             AstExplainer(functionDefinitionAst);
             return base.VisitFunctionDefinition(functionDefinitionAst);
         }
@@ -703,7 +704,7 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitNamedAttributeArgument(NamedAttributeArgumentAst namedAttributeArgumentAst)
         {
-            // TODO
+            // TODO: add named attribute argument explanation
             AstExplainer(namedAttributeArgumentAst);
             return base.VisitNamedAttributeArgument(namedAttributeArgumentAst);
         }
@@ -717,14 +718,14 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitParamBlock(ParamBlockAst paramBlockAst)
         {
-            // TODO
+            // TODO: add param block explanation
             AstExplainer(paramBlockAst);
             return base.VisitParamBlock(paramBlockAst);
         }
 
         public override AstVisitAction VisitParameter(ParameterAst parameterAst)
         {
-            // TODO
+            // TODO: add parameter explanation
             AstExplainer(parameterAst);
             return base.VisitParameter(parameterAst);
         }
@@ -755,7 +756,7 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitReturnStatement(ReturnStatementAst returnStatementAst)
         {
-            // TODO
+            // TODO: add return statement explanation
             AstExplainer(returnStatementAst);
             return base.VisitReturnStatement(returnStatementAst);
         }
@@ -850,21 +851,21 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitSwitchStatement(SwitchStatementAst switchStatementAst)
         {
-            // TODO
+            // TODO: add switch statement explanation
             AstExplainer(switchStatementAst);
             return base.VisitSwitchStatement(switchStatementAst);
         }
 
         public override AstVisitAction VisitThrowStatement(ThrowStatementAst throwStatementAst)
         {
-            // TODO
+            // TODO: add throw statement explanation
             AstExplainer(throwStatementAst);
             return base.VisitThrowStatement(throwStatementAst);
         }
 
         public override AstVisitAction VisitTrap(TrapStatementAst trapStatementAst)
         {
-            // TODO
+            // TODO: add trap explanation
             AstExplainer(trapStatementAst);
             return base.VisitTrap(trapStatementAst);
         }
@@ -934,7 +935,7 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         public override AstVisitAction VisitUsingExpression(UsingExpressionAst usingExpressionAst)
         {
-            // TODO
+            // TODO: add using expression explanation
             AstExplainer(usingExpressionAst);
             return base.VisitUsingExpression(usingExpressionAst);
         }

--- a/explainpowershell.analysisservice/AstVisitorExplainer.cs
+++ b/explainpowershell.analysisservice/AstVisitorExplainer.cs
@@ -17,6 +17,7 @@ namespace ExplainPowershell.SyntaxAnalyzer
         private const char filterChar = (char)17;
         private const string PartitionKey = "CommandHelp";
         private readonly List<Explanation> explanations = new();
+        private string errorMessage;
         private string extent;
         private int offSet = 0;
         private readonly TableClient tableClient;
@@ -45,7 +46,8 @@ namespace ExplainPowershell.SyntaxAnalyzer
             {
                 Explanations = explanations,
                 DetectedModules = modules,
-                ExpandedCode = extent
+                ExpandedCode = extent,
+                ParseErrorMessage = errorMessage
             };
 
             return analysisResult;
@@ -267,7 +269,10 @@ namespace ExplainPowershell.SyntaxAnalyzer
             {
                 var helpResults = HelpTableQueryRange(resolvedCmd);
                 helpResult = helpResults?.FirstOrDefault();
-                // TODO: Warn user that more than one explanation is available
+                if (helpResults.Count > 1)
+                {
+                    this.errorMessage = $"The command '{helpResult?.CommandName}' is present in more than one module: '{string.Join("', '", helpResults.Select(r => r.ModuleName))}'. Explicitly prepend the module name to the command to select one: '{helpResults.First().ModuleName}\\{helpResult?.CommandName}'";
+                }
             }
             else
             {

--- a/explainpowershell.analysisservice/SyntaxAnalyzer.cs
+++ b/explainpowershell.analysisservice/SyntaxAnalyzer.cs
@@ -58,7 +58,9 @@ namespace ExplainPowershell.SyntaxAnalyzer
                 return ResponseHelper(HttpStatusCode.InternalServerError, "Oops, someting went wrong internally. Please file an issue with the PowerShell code you submitted when this occurred.");
             }
 
-            analysisResult.ParseErrorMessage = parseErrors?.FirstOrDefault()?.Message;
+            analysisResult.ParseErrorMessage = string.IsNullOrEmpty(analysisResult.ParseErrorMessage)
+                ? parseErrors?.FirstOrDefault()?.Message
+                : analysisResult.ParseErrorMessage + "\n" + parseErrors?.FirstOrDefault()?.Message;
 
             var json = System.Text.Json.JsonSerializer.Serialize(analysisResult);
 

--- a/explainpowershell.metadata/defaultModules.json
+++ b/explainpowershell.metadata/defaultModules.json
@@ -26,5 +26,13 @@
     {
         "Name": "PSReadLine",
         "ProjectUri": "https://docs.microsoft.com/en-us/powershell/module/psreadline"
+    },
+    {
+        "Name": "myTestModule",
+        "ProjectUri": "https://www.explainpowershell.com"
+    },
+    {
+        "Name": "myConflictingTestModule",
+        "ProjectUri": "https://www.explainpowershell.com"
     }
 ]


### PR DESCRIPTION
Adds support for modules with cmdlets that clobber. So for instance we could now have Hyper-V and Vmware modules loaded in the database at the same time, and 'Get-VM' would then be handled correctly. 

'Get-Vm' without the module specifier would result in a user warning indicating that this command is present in more than one module, explaining how to use the module prepend syntax.

'hyper-v\get-vm' would result in the Hyper-V help info being presented.