### PR TITLE
fix failing explanation for `. {}` and `& {}`

### DIFF
--- a/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
+++ b/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
@@ -7,6 +7,13 @@ Describe "Invoke-SyntaxAnalyzer" {
         . $PSScriptRoot/Test-IsAzuriteUp.ps1
     }
 
+    It "Should not fail explaining ``. {}``" {
+        $code = '. {}'
+        [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code
+        $content = $result.Content | ConvertFrom-Json
+        $content.Explanations | Should -Not -BeNullOrEmpty
+    }
+
     It "Switches to the right module on demand" {
         $code = 'myTestModule\get-testinfo'
         [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code

--- a/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
+++ b/explainpowershell.analysisservice.tests/Invoke-SyntaxAnalyzer.Tests.ps1
@@ -7,6 +7,13 @@ Describe "Invoke-SyntaxAnalyzer" {
         . $PSScriptRoot/Test-IsAzuriteUp.ps1
     }
 
+    It "Should not fail explaining ``. {gci -path 'sdf'}``" {
+        $code = '. {}'
+        [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code
+        $content = $result.Content | ConvertFrom-Json
+        $content.Explanations | Should -Not -BeNullOrEmpty
+    }
+
     It "Should not fail explaining ``. {}``" {
         $code = '. {}'
         [BasicHtmlWebResponseObject]$result = Invoke-SyntaxAnalyzer -PowerShellCode $code

--- a/explainpowershell.analysisservice/AstVisitorExplainer.cs
+++ b/explainpowershell.analysisservice/AstVisitorExplainer.cs
@@ -97,6 +97,10 @@ namespace ExplainPowershell.SyntaxAnalyzer
 
         private void ExpandAliasesInExtent(CommandAst cmd, string resolvedCmd)
         {
+            if (string.IsNullOrEmpty(resolvedCmd)) {
+                return;
+            }
+
             int start = offSet + cmd.Extent.StartOffset;
             int length = offSet + cmd.CommandElements[0].Extent.EndOffset - start;
             extent = extent
@@ -260,11 +264,6 @@ namespace ExplainPowershell.SyntaxAnalyzer
             }
 
             string resolvedCmd = Helpers.ResolveAlias(cmdName) ?? cmdName;
-
-            if (string.IsNullOrEmpty(resolvedCmd))
-            {
-                resolvedCmd = cmdName;
-            }
 
             HelpEntity helpResult;
             if (string.IsNullOrEmpty(moduleName))

--- a/explainpowershell.analysisservice/AstVisitorExplainer.cs
+++ b/explainpowershell.analysisservice/AstVisitorExplainer.cs
@@ -250,7 +250,8 @@ namespace ExplainPowershell.SyntaxAnalyzer
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
             string moduleName = string.Empty;
-            string cmdName = commandAst.GetCommandName();
+            string cmdName = commandAst.GetCommandName() ?? string.Empty;
+
             if (cmdName.IndexOf('\\') != -1)
             {
                 var s = cmdName.Split('\\');

--- a/explainpowershell.frontend/Pages/Index.razor.cs
+++ b/explainpowershell.frontend/Pages/Index.razor.cs
@@ -77,6 +77,8 @@ namespace explainpowershell.frontend.Pages
             Waiting = false;
             RequestHasError = false;
             ReasonPhrase = string.Empty;
+            TreeItems = new HashSet<TreeItem<Explanation>>();
+            ExpandedCode = null;
 
             if (string.IsNullOrEmpty(InputValue))
                 return;


### PR DESCRIPTION
Fixes #75.

When calling `. {}` or `& {}`, the command is `{}`, and the operator going with it is `.` or `&`. So when handling explanations, we need to account for the fact that the name of the command could be null, as in the case of `{}`.